### PR TITLE
solanum isn't really upcoming anymore

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
     <h1 class="text-center">{{ site.title }}</h1>
 
     <p class="text-center">
-      Solanum is the upcoming IRCd that's being worked on by a collaboration of
+      Solanum is the IRCd that's being worked on by a collaboration of
       <a href="https://libera.chat">Libera Chat</a> and <a href="https://www.oftc.net">OFTC</a> staff.
     </p>
 


### PR DESCRIPTION
Given the amount of time Solanum has spent in production on Libera Chat (and probably other networks too), it feels strange to still call it an upcoming IRCd